### PR TITLE
Add a README about the standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# NIMADS
+
+The Neuroimaging Meta-Analysis Data Standard (NIMADS) is a standard for organizing and annotating
+meta-analytic data from neuroimaging (especially fMRI) studies.
+
+NIMADS is specified in a series of [JSON-LD](https://json-ld.org) files,
+each of which describes a single element of the standard.
+
+NIMADS is still under active development.

--- a/README.md
+++ b/README.md
@@ -7,3 +7,6 @@ NIMADS is specified in a series of [JSON-LD](https://json-ld.org) files,
 each of which describes a single element of the standard.
 
 NIMADS is still under active development.
+If you would like to contribute to NIMADS, or even just ask a question about it,
+please either [open an issue](https://github.com/neurostuff/NIMADS/issues/new) or
+get in touch with us [on Mattermost](https://mattermost.brainhack.org/brainhack/channels/nimare).


### PR DESCRIPTION
I wanted to add information about NIMADS into the NiMARE user guide I'm working on (see https://github.com/neurostuff/NiMARE/pull/727), and I realized that NIMADS doesn't have any documentation anywhere, so I figured I should add _something_.